### PR TITLE
Fix Lithuanian Party Parrot Colors

### DIFF
--- a/data/countryColors.json
+++ b/data/countryColors.json
@@ -1877,13 +1877,13 @@
   "name": "Lithuania",
   "colors": [{
     "hex": "#FDB913",
-    "percent": 33
+    "percent": 33.33
   }, {
     "hex": "#006A44",
-    "percent": 33
+    "percent": 33.33
   }, {
     "hex": "#C1272D",
-    "percent": 33
+    "percent": 33.34
   }]
 }, {
   "name": "Luxembourg",

--- a/data/countryColors.json
+++ b/data/countryColors.json
@@ -1879,17 +1879,11 @@
     "hex": "#FDB913",
     "percent": 33
   }, {
-    "hex": "#C1272D",
+    "hex": "#006A44",
     "percent": 33
   }, {
-    "hex": "#006A44",
-    "percent": 32
-  }, {
-    "hex": "#40543D",
-    "percent": 1
-  }, {
-    "hex": "#548533",
-    "percent": 1
+    "hex": "#C1272D",
+    "percent": 33
   }]
 }, {
   "name": "Luxembourg",


### PR DESCRIPTION
It appears, that Lithuanian Party Parrot parties in the wrong colors 😭 
The Parrot changes colors in the following order: Yellow -> Red -> Green, however Lithuanian flag looks like this:

![800px-flag_of_lithuania](https://user-images.githubusercontent.com/1528367/32915984-5753fb22-cb23-11e7-9006-787f3dc2c5c5.png)

It has to be Yellow -> Green -> Red

Let's make Lithuanian Party Parrot party in the correct colors!

![party parrot](https://user-images.githubusercontent.com/1528367/32916104-b2cbef5a-cb23-11e7-9300-569bcf8c7d22.gif)
